### PR TITLE
feat: add support for gitloom hash-object command

### DIFF
--- a/cmd/hash_object.go
+++ b/cmd/hash_object.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/MahendraDani/gitloom.git/internal/object"
 	"github.com/MahendraDani/gitloom.git/internal/repo"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +23,7 @@ var hashObjectCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		hash, err := repo.HashObject(file, r)
+		hash, err := object.HashObject(file, r)
 		if err != nil {
 			fmt.Println("Error:", err)
 			os.Exit(1)

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -1,4 +1,4 @@
-package repo
+package object
 
 import (
 	"bufio"
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/MahendraDani/gitloom.git/internal/repo"
 )
 
-func HashObject(filePath string, r *Repository) (string, error) {
+func HashObject(filePath string, r *repo.Repository) (string, error) {
 	if r == nil {
 		return "", errors.New("gitloom repository not found. First initialize gitloom repository")
 	}
@@ -58,12 +60,12 @@ func computeSHA1(blob []byte) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func writeObject(blob []byte, hash string, r *Repository) error {
-	objDir := filepath.Join(r.Path, ObjectsDir, hash[:2])
+func writeObject(blob []byte, hash string, r *repo.Repository) error {
+	objDir := filepath.Join(r.Path, repo.ObjectsDir, hash[:2])
 	objPath := filepath.Join(objDir, hash[2:])
 
 	// Ensure directory exists
-	if err := os.MkdirAll(objDir, DirPerm); err != nil {
+	if err := os.MkdirAll(objDir, repo.DirPerm); err != nil {
 		return err
 	}
 

--- a/internal/object/object_test.go
+++ b/internal/object/object_test.go
@@ -1,4 +1,4 @@
-package repo_test
+package object_test
 
 import (
 	"bytes"
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/MahendraDani/gitloom.git/internal/object"
 	"github.com/MahendraDani/gitloom.git/internal/repo"
 )
 
@@ -31,7 +32,7 @@ func TestHashObject(t *testing.T) {
 	}
 
 	// Call HashObject
-	hash, err := repo.HashObject(filePath, r)
+	hash, err := object.HashObject(filePath, r)
 	if err != nil {
 		t.Fatalf("HashObject returned error: %v", err)
 	}


### PR DESCRIPTION
## Proposed Changes
Implemented `gitloom hash-object <file>` command:
1. converts a file into a blob object 
2. prepends a header `blog <size>\0` to the file content.
3. computes SHA-1 hash of the blob.
4. stores the compressed blob in `.gitloom/objects/<hash_prefix>/<hash_suffix>`

The SHA1 generated code is of 40 chars, the `hash_prefix` is the first two chars and the rest is treated as `hash_suffix`. 